### PR TITLE
boot-extract.c: Fix typo in file handle names

### DIFF
--- a/boot-extract.c
+++ b/boot-extract.c
@@ -167,7 +167,7 @@ int main(int argc, char **argv)
 			printf ("Error in read\n");
 			return 1;
 		}
-		write(fk, buf, hdr.ramdisk_size);
+		write(fr, buf, hdr.ramdisk_size);
 		free(buf);
 		close(fr);
 		printf("ramdisk.cpio.gz extracted\n");
@@ -198,7 +198,7 @@ int main(int argc, char **argv)
 			printf ("Error in read\n");
 			return 1;
 		}
-		write(fk, buf, hdr.second_size);
+		write(fr, buf, hdr.second_size);
 		free(buf);
 		close(fr);
 		printf("second.dtb extracted\n");


### PR DESCRIPTION
When dumping the ramdisk and dtb the incorrect file handle was
written to. This happens to work in most cases due to the way
filehandles are reused, but is obviously not a safe thing to do.